### PR TITLE
Static & media management

### DIFF
--- a/docs/static_management/index.md
+++ b/docs/static_management/index.md
@@ -1,0 +1,64 @@
+# Static files management
+
+> **Quick usage workflow:**
+> 
+> When in dev mode, static files are managed automatically for you.
+> 
+> When in production mode, every time you make a change in static files, run `manage.py collectstatic`.
+
+## Introduction
+
+Some definitions first:
+* *Static files* are images, CSS, JS or other files that we as developers create for the website.
+* *Media files* are user-generated files that are uploaded through a `FileField`.
+
+## Where do they live?
+
+Static files can be created:
+* In each app's `static/` folder (default Django locations).
+* In additional locations defined by the `STATICFILES_DIRS` setting. In our project these are:
+  * `project/static/` for project-level static files and
+  * `bundles/dist/` when in production, or `bundles/build-dev/` when in development (see [bundling docs](../webpack/index.md)).
+
+Media files are stored by default in `MEDIA_ROOT` which for our project is the `media/` folder.
+
+### For example
+* The logo –which is a project-level static file– will be stored in `project/static/`.
+* The venue photos –that are specific to the homepage– will be stored in `project/home/static/`.
+* The team photos –that will be uploaded through a `FileField` of the admin interface– will be stored somewhere in `media/` (e.g. `media/team/`).
+
+## How do we serve them?
+
+This depends on whether we are in development or production mode. When in production mode, serving such files via Django is a major **performance overhead**. That's why [the Django docs encourage us not to](https://docs.djangoproject.com/en/stable/howto/static-files/deployment/).
+
+## How do we serve them in production mode then?
+
+Serving images, CSS, JS or any other static (and media) files is better handled directly by our web server, if not a separate dedicated server.
+
+We just need to add directives to map `static/` and `media/` URLs to the corresponding folders. Example Apache configuration [here](https://docs.djangoproject.com/en/stable/howto/deployment/wsgi/modwsgi/#serving-files).
+
+### Yes, but my static files are split among many directories. Wouldn't it be nicer if all lived in a single folder?
+
+This is where the management command `collectstatic` comes in and does exactly that: it automatically discovers all static files and moves them to the root-level `static/` folder (or whatever `STATIC_ROOT` is).
+
+**WARNING!** Do not place or edit any file directly from the `static/` folder. Use the `STATICFILES_DIRS` instead and run `collectstatic` again to update the contents.
+
+## What about development mode?
+
+Running `collectstatic` every time to gather the static files would be cumbersome while developing. That's why Django's `runserver` does it automatically when `DEBUG` is `True`.
+
+But now we are missing the mapping from URLs to the folders. Django provides the [`static`](https://docs.djangoproject.com/en/stable/howto/static-files/#serving-static-files-during-development) helper for that, so we can just add to `project/urls.py` the following:
+
+```python
+from django.conf import settings
+from django.conf.urls.static import static
+
+# ... the rest of your URLconf goes here ...
+
+urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+```
+
+This will map `static/` URLs to the `static/` folder and `media/` URLs to the `media/` folder.
+
+**WARNING!** The static helper also only works when `DEBUG` is `True`, otherwise it returns `[]`.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,14 +1,11 @@
 # Project structure
 
-* `__sized__/`
-  * `static/`
-    Resized (warmed) image files are saved here by default
 * `docs/`  
   Project-level documentation needs to be stored here and be written in Markdown. Module-specific documentation may be located only in source files.
 * [`bundles/`](webpack/structure.md)
 * `assets/`  
   Project-level CSS and JS scripts. For documentation on the bundling process, check [here](webpack/index.md).
-* `etc/`
+* `etc/`  
   Extra files that accompany the project, such as configuration of external tools etc.
 * `project/`
     * [`home/`](home/index.md)
@@ -19,12 +16,16 @@
     * [`privacy/`](privacy/index.md)
     * [`license/`](license/index.md)
     * [`contact/`](contact/index.md)
+    * `static/`  
+      Project-level static files (e.g. logo) live here.
     * `settings/`  
       Settings module that reads from *.env* and exports configuration parameters to Django.
     * `urls.py`  
       Top-level routing instructions.
-* `static/`
-  Static files like image files, will be saved here.
+* `media/`  
+  User-generated media files will be stored here. More info [here](static_management/index.md).
+* `static/`  
+  Static files (CSS, JS, images, etc.) from `STATICFILES_DIRS` are gathered here. **Do not** place or edit any files in it, since all the management is done automatically by Django's `collectstatic` command. More info [here](static_management/index.md).
 * `manage.py`  
   Django command-line tool.
 * `pylintrc`  
@@ -34,8 +35,8 @@
 * `_version.py`  
   Contains a `__version__` variable to indicate the current version of the website. Calendar versioning is used.
 * `setup.py`  
-  Setup script.
+  Setup script. Dependencies must also be included here.
 * `requirements.txt`  
   Pinned production dependencies.
-* `requirements-dev.txt`
+* `requirements-dev.txt`  
   Pinned development dependencies.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,3 +13,5 @@ To initiate the server run:
 ```
 $ python manage.py runserver --settings=project.settings.prod
 ```
+
+For static files management you'll need to read the [related docs](static_management/index.md).

--- a/docs/webpack/django.md
+++ b/docs/webpack/django.md
@@ -39,11 +39,6 @@ INSTALLED_APPS = [
     'webpack_loader',
     ...
 ]
-
-# django-webpack-loader will use this as a base directory for the `BUNDLE_DIR_NAME` configuration.
-STATICFILES_DIRS = (
-    abs_path('bundles'),
-)
 ```
 
 ### Dev
@@ -51,10 +46,15 @@ STATICFILES_DIRS = (
 ```python
 # project/settings/dev.py
 
+# django-webpack-loader will use this as a base directory for the `BUNDLE_DIR_NAME` configuration.
+STATICFILES_DIRS = (
+    abs_path('bundles/build-dev'),
+)
+
 WEBPACK_LOADER = {
     'DEFAULT': {
         # Webpack outputs bundles in bundles/build-dev/ when in development mode.
-        'BUNDLE_DIR_NAME': 'build-dev/',
+        'BUNDLE_DIR_NAME': '/',
         'STATS_FILE': abs_path('bundles', 'webpack-stats.dev.json'),
     }
 }
@@ -65,10 +65,14 @@ WEBPACK_LOADER = {
 ```python
 # project/settings/prod.py
 
+STATICFILES_DIRS = (
+    abs_path('bundles/dist'),
+)
+
 WEBPACK_LOADER = {
     'DEFAULT': {
         # Webpack outputs bundles in bundles/dist/ when in production mode.
-        'BUNDLE_DIR_NAME': 'dist/',
+        'BUNDLE_DIR_NAME': '/',
         'STATS_FILE': abs_path('bundles', 'webpack-stats.prod.json')
     }
 }

--- a/docs/webpack/usage.md
+++ b/docs/webpack/usage.md
@@ -88,6 +88,12 @@ npm run build:dev
 >
 > `bundles/build-dev/` and `webpack-stats.dev.json` are not to be committed to the repository and thus they are listed in `bundles/.gitignore`.
 
+To avoid running `npm run build:dev` everytime you make a change you can use the *watch mode* that does this automatically, by running:
+```bash
+cd bundles
+npm run watch
+```
+
 ### Production mode
 
 Generates and stores the bundles in `bundles/dist/`:
@@ -96,6 +102,8 @@ Generates and stores the bundles in `bundles/dist/`:
 cd bundles
 npm run build
 ```
+
+Read [static files management docs](../static_management/index.md) on how to deploy static files when in production mode.
 
 ## Referencing a Webpack bundle in Django templates
 

--- a/project/partners/models.py
+++ b/project/partners/models.py
@@ -60,7 +60,7 @@ class Partner(models.Model):
 
     image = VersatileImageField(
         'Image',
-        upload_to='static/',
+        upload_to='partners/',
         width_field='image_width',
         height_field='image_height'
     )

--- a/project/program/models.py
+++ b/project/program/models.py
@@ -154,7 +154,7 @@ class Activity(models.Model):
 
     image = VersatileImageField(
         'Image',
-        upload_to='static/',
+        upload_to='activities/',
         width_field='image_width',
         height_field='image_height',
         null=True,
@@ -250,7 +250,7 @@ class Presenter(models.Model):
 
     image = VersatileImageField(
         'Image',
-        upload_to='static/',
+        upload_to='presenters/',
         width_field='image_width',
         height_field='image_height'
     )

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -87,6 +87,9 @@ AUTH_PASSWORD_VALIDATORS = [
 STATIC_URL = env_str('STATIC_URL', '/static/')
 STATIC_ROOT = env_str('STATIC_ROOT', abs_path('static'))
 
+MEDIA_URL = env_str('MEDIA_URL', '/media/')
+MEDIA_ROOT = env_str('MEDIA_ROOT', abs_path('media'))
+
 STATICFILES_DIRS = (
     abs_path('project/static'),
 )
@@ -135,9 +138,9 @@ VERSATILEIMAGEFIELD_SETTINGS = {
     'cache_length': 2592000,
     'cache_name': 'versatileimagefield_cache',
     'jpeg_resize_quality': 70,
-    'sized_directory_name': '__sized__',
-    'filtered_directory_name': '__filtered__',
-    'placeholder_directory_name': '__placeholder__',
+    'sized_directory_name': 'media/__sized__',
+    'filtered_directory_name': 'media/__filtered__',
+    'placeholder_directory_name': 'media/__placeholder__',
     'create_images_on_demand': False,
     'image_key_post_processor': None,
     'progressive_jpeg': False

--- a/project/team/models.py
+++ b/project/team/models.py
@@ -59,7 +59,7 @@ class TeamMember(models.Model):
 
     image = VersatileImageField(
         'Image',
-        upload_to='static/',
+        upload_to='team/',
         width_field='image_width',
         height_field='image_height'
     )

--- a/project/urls.py
+++ b/project/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     path('partners/', include('project.partners.urls')),
     path('team/', include('project.team.urls')),
     path('about/', include('project.about.urls')),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) \
+  + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
[Docs](https://github.com/tdiam/tedxntua2019/tree/static_media_management/docs/static_management/index.md)

Changes:
- `MEDIA_ROOT` changed from `''` to `'media/'`
- `VersatileImageField`s now store images in `media/{partners, team, ...}` and resized ones in `media/__sized__/{partners, team, ...}`
- Added media URLs in `project/urls.py`